### PR TITLE
SAML as authentication method and cleanup

### DIFF
--- a/config/central-logging-google-idp-metadata.xml
+++ b/config/central-logging-google-idp-metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://accounts.google.com/o/saml2?idpid=C03esjmtc" validUntil="2027-06-01T10:30:51.000Z">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDdDCCAlygAwIBAgIGAYEj98/LMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ
+bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv
+b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMjIwNjAy
+MTAzMDUxWhcNMjcwNjAxMTAzMDUxWjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx
+CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEA4+m+5/wNGsDwGbHNmw9ZZBUM/bGXN43bB96rRs5b72J23gczx1eIuRSlOnXaPiHI
++MIohfd/FSqygO+Epzlv56R9i6MzhYiRAof+h6ZWnoaIca4IgEZvaHiaGYe43P1s/t5/hf/TEQEL
+zEc2wsypmTF6Vq3ccqDLheKIwPenRogkA9eKFZUfxpNefbpzmsAgT5hRs4khv4unzSHCgO3s28FT
+UvvqKhYJSN6OkoY4v9aPJ1m3TZRY4SVzZkiE6pzZB6dbuMdVWj/Dpc+3fBH1vYVAdg5PIyr3P8/g
+iNGgvE/lejsHxs2XqEquKtpurLq8Vo03TD5e5NxsPBFmBxAqkwIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQBNqRc1wdh+3Wr7LALJzgWDeppSOwRudR8XZ9W4gbo3OJRn2P7IVu2OC7EdPZsYR9qAgWym
+Nk97GKNAh9GAV4XXNogWxb6OeGy1A40Yyu0XABGhl5axJqT97ZMgdk9Z7806fu3GwQut4a6LaQuz
+gQdo18QMvp2vb+SuubX++S5H5QcIYUgQMU8ll873pj9ut8bicQUJ44JF83qzTTi5DRBjG4z2yltk
+iu0w7DU40RMOBOTu93L9Rj6dVTrirJ4cji16In2hABw7dXIp2eJuCLeEUs2Zd4x3q6DwDBf+FHhO
++9gRjBS2u6DG6yuV3y94Y5aOBNurIiqgyWleCIV5bJVy</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://accounts.google.com/o/saml2/idp?idpid=C03esjmtc"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://accounts.google.com/o/saml2/idp?idpid=C03esjmtc"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/templates/security.yml.tmpl
+++ b/templates/security.yml.tmpl
@@ -103,17 +103,17 @@ config:
           config:
             idp:
               metadata_file: central-logging-google-idp-metadata.xml #SAML's metadata url, provided by your IdP
-              entity_id: https://accounts.google.com/o/saml2?idpid=C03esjmtc #SAML's IdP entity ID, provided by your IdP
+              entity_id: {{ getenv "SAML_IDP_ENTITY_ID" "https://accounts.google.com/o/saml2?idpid=xxxyyyzzz" }} #SAML's IdP entity ID, provided by your IdP
               enable_ssl_client_auth: true
               pemcert_filepath: /srv/ssl/sp.crt
               pemkey_filepath: /srv/ssl/sp.key
             sp:
-              entity_id: logs.ramsalt.com
+              entity_id: {{ getenv "SAML_SP_ENTITY_ID" "opensearch-dashboards.example.com" }}
               forceAuthn: true
-            kibana_url: https://logs.ramsalt.com
+            kibana_url: {{ getenv "DASHBOARDS_ENDPOINT_URL" "https://opensearch-dashboards.example.com" }}
             subject_key: NameID
             roles_key: Groups
-            exchange_key: 387b9923000dfd3bdb4d4b8691f8d15a02829a2e573ae8300a4ea6695152cf38
+            exchange_key: {{ getenv "SAML_EXCHANGE_KEY" "configure_exchange_key" }}
         authentication_backend:
           type: noop
       openid_auth_domain:

--- a/templates/security.yml.tmpl
+++ b/templates/security.yml.tmpl
@@ -82,20 +82,6 @@ config:
         ###### and here https://tools.ietf.org/html/rfc7239
         ###### and https://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Remote_IP_Valve
     authc:
-      kerberos_auth_domain:
-        http_enabled: false
-        transport_enabled: false
-        order: 6
-        http_authenticator:
-          type: kerberos
-          challenge: true
-          config:
-            # If true a lot of kerberos/security related debugging output will be logged to standard out
-            krb_debug: false
-            # If true then the realm will be stripped from the user name
-            strip_realm_from_principal: true
-        authentication_backend:
-          type: noop
       basic_internal_auth_domain:
         description: "Authenticate via HTTP Basic against internal users database"
         http_enabled: true
@@ -106,10 +92,34 @@ config:
           challenge: false
         authentication_backend:
           type: internal
+      saml_auth:
+        order: 1
+        description: "Google Workspace SAML"
+        http_enabled: true
+        transport_enabled: false
+        http_authenticator:
+          type: saml
+          challenge: true
+          config:
+            idp:
+              metadata_file: central-logging-google-idp-metadata.xml #SAML's metadata url, provided by your IdP
+              entity_id: https://accounts.google.com/o/saml2?idpid=C03esjmtc #SAML's IdP entity ID, provided by your IdP
+              enable_ssl_client_auth: true
+              pemcert_filepath: /srv/ssl/sp.crt
+              pemkey_filepath: /srv/ssl/sp.key
+            sp:
+              entity_id: logs.ramsalt.com
+              forceAuthn: true
+            kibana_url: https://logs.ramsalt.com
+            subject_key: NameID
+            roles_key: Groups
+            exchange_key: 387b9923000dfd3bdb4d4b8691f8d15a02829a2e573ae8300a4ea6695152cf38
+        authentication_backend:
+          type: noop
       openid_auth_domain:
         http_enabled: true
         transport_enabled: true
-        order: 1
+        order: 2
         http_authenticator:
           type: openid
           challenge: false
@@ -118,78 +128,6 @@ config:
             openid_connect_url: "{{ getenv "OIDC_CONNECT_URL" "https://accounts.google.com/.well-known/openid-configuration" }}"
         authentication_backend:
           type: noop
-      proxy_auth_domain:
-        description: "Authenticate via proxy"
-        http_enabled: false
-        transport_enabled: false
-        order: 3
-        http_authenticator:
-          type: proxy
-          challenge: false
-          config:
-            user_header: "x-proxy-user"
-            roles_header: "x-proxy-roles"
-        authentication_backend:
-          type: noop
-      jwt_auth_domain:
-        description: "Authenticate via Json Web Token"
-        http_enabled: false
-        transport_enabled: false
-        order: 0
-        http_authenticator:
-          type: jwt
-          challenge: false
-          config:
-            signing_key: "base64 encoded HMAC key or public RSA/ECDSA pem key"
-            jwt_header: "Authorization"
-            jwt_url_parameter: null
-            jwt_clock_skew_tolerance_seconds: 30
-            roles_key: null
-            subject_key: null
-        authentication_backend:
-          type: noop
-      clientcert_auth_domain:
-        description: "Authenticate via SSL client certificates"
-        http_enabled: false
-        transport_enabled: false
-        order: 2
-        http_authenticator:
-          type: clientcert
-          config:
-            username_attribute: cn #optional, if omitted DN becomes username
-          challenge: false
-        authentication_backend:
-          type: noop
-      ldap:
-        description: "Authenticate via LDAP or Active Directory"
-        http_enabled: false
-        transport_enabled: false
-        order: 5
-        http_authenticator:
-          type: basic
-          challenge: false
-        authentication_backend:
-          # LDAP authentication backend (authenticate users against a LDAP or Active Directory)
-          type: ldap
-          config:
-            # enable ldaps
-            enable_ssl: false
-            # enable start tls, enable_ssl should be false
-            enable_start_tls: false
-            # send client certificate
-            enable_ssl_client_auth: false
-            # verify ldap hostname
-            verify_hostnames: true
-            hosts:
-            - localhost:8389
-            bind_dn: null
-            password: null
-            userbase: 'ou=people,dc=example,dc=com'
-            # Filter to search for users (currently in the whole subtree beneath userbase)
-            # {0} is substituted with the username
-            usersearch: '(sAMAccountName={0})'
-            # Use this attribute from the user as username (if not set then DN is used)
-            username_attribute: null
     authz:
       roles_from_myldap:
         description: "Authorize via LDAP or Active Directory"


### PR DESCRIPTION
- Add SAML configuration to use Google Workspace as SAML IdP.
- Remove unused/unneeded authentication methods.

Related to https://github.com/ramsalt/opensearch-dashboards/pull/1